### PR TITLE
Export required symbols for better separation of packages

### DIFF
--- a/defrest.lisp
+++ b/defrest.lisp
@@ -31,7 +31,7 @@
 (defpackage defrest 
   (:use :cl :hunchentoot :cl-ppcre :split-sequence) 
   (:nicknames rest)
-  (:export defrest create-rest-table-dispatcher undefrest))
+  (:export defrest create-rest-table-dispatcher undefrest start easy-acceptor))
 
 (in-package :rest)
 


### PR DESCRIPTION
I'm making this patch as a part of a personal project, I want to be able to use dearest to define a rest api without being in the dearest package. 

Thanks for making this project! It's been helpful. 