### PR TITLE
Query param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,55 @@ or more sophisticated with embedded Path-Parameters and json response
 ```
 
 This will build a dispatcher which will listen to urls with the regexp `"/length/.+"` , bind the (.+) to the `str` variable , runs the body with it and sends the result.
+
 Path-Parameters are encoded as Template blocks {VARNAME:REGEXP}. defrest will do all the parsing and matching for you.
 Additionally the hunchentoot handler environment is available, so you can access `hunchentoot:*request*` and so on.
+
+`defrest` also supports query parameters:
+
+```lisp
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query offset limit)
+        (get-songs album-id offset limit))
+```
+
+Query-Parameters are separated from the path-parameters by the keyword ```:query```. They are not used by the route matching
+algorithm. Query-Parameters can be declared as simple variable names (where the names represents the names of the query parameters of the current request) or as lambda-lists with the following format:
+
+query-param -- (binding &key (mandatory nil) (pattern nil) (param nil) (default nil))
+
+* _binding_ -- Name of the variable bound to the value of the query-parameter in the execution context of the body.
+* _mandatory_ -- A generalized boolean that indicates if the query-parameter is mandatory. If a query-parameter
+    is mandatory but not provided by the current request the HTTP status code 400 (Bad Request) is returned.
+    If a query-parameter is not mandatory and not provided by the current request it gets the value NIL (if
+    no default value has been declared).
+* _pattern_ A regexp that the query parameter must match. If the query parameter does not match the pattern,
+    the HTTP status code 400 (Bad Request) is returned.
+* _param_ Name of the query-parameter as provided by the current request. The default value is the value of _binding_.
+* _default_ Default value of the query parameter. 
+
+Query-Parameter examples:
+
+```lisp
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") limit)
+        (get-songs album-id offset limit))
+```
+
+```lisp
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") (limit :mandatory t))
+        (get-songs album-id offset limit))
+```
+
+```lisp
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") (limit :mandatory t :pattern "[0-9]+"))
+        (get-songs album-id offset limit))
+```
+
+```lisp
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") (count :mandatory t :param "limit"))
+        (get-songs album-id offset count))
+```
+
+
 
 The defrest body should return a string. All other values are format~a'ed to it.
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Query-Parameter examples:
 ```
 
 ```lisp
-(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") (limit :mandatory t :pattern "[0-9]+"))
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") 
+    (limit :mandatory t :pattern "[0-9]+"))
         (get-songs album-id offset limit))
 ```
 
 ```lisp
-(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") (count :mandatory t :param "limit"))
+(defrest "/songs/{album-id:[0-9]+}" :GET (album-id :query (offset :default "0") 
+    (count :mandatory t :param "limit"))
         (get-songs album-id offset count))
 ```
 

--- a/defrest.asd
+++ b/defrest.asd
@@ -24,4 +24,4 @@
   
 
 (defmethod perform ((op test-op) (c (eql (find-system :defrest.test))))
-  (funcall (intern (symbol-name '#:run!) :it.bese.FiveAM)))
+  (funcall (intern (symbol-name '#:run-all-tests) :it.bese.FiveAM)))

--- a/defrest.asd
+++ b/defrest.asd
@@ -11,7 +11,8 @@
   :license "BSD"
   :depends-on (:hunchentoot
 	       :cl-ppcre
-	       :split-sequence)
+	       :split-sequence
+	       :quri)
   :in-order-to ((test-op (test-op "defrest.test")))
   :components ((:static-file "defrest.asd")
 	       (:file "defrest")))

--- a/defrest.lisp
+++ b/defrest.lisp
@@ -110,6 +110,8 @@ Example 4:
 
 (Defun parse-uri (schema uri)
   "Parses URI against SCHEMA and returns a hashtable with all pathvariable bindings"
+  (let ((parsed-uri (quri:uri (hunchentoot:url-decode uri))))
+    (setf uri (quri:uri-path parsed-uri))
     (when (not 
 	   (scan 
 	    (schema->regexpurl schema)
@@ -117,18 +119,17 @@ Example 4:
       (error "Uri does not match schema"))
     (let ((parsed (parse-schema schema))
 	  (map (make-hash-table :test #'equalp)))
- 
-     (loop for token in parsed do
+    (loop for token in parsed do
 	 (if (listp token)
 	     (let ((regexp (getf token :regexp))
 		   (key (getf token :key)))
 	       (multiple-value-bind (start end) (scan regexp uri)
-		 (setf (gethash key map) (hunchentoot:url-decode (subseq uri start end)))
+		 (setf (gethash key map) (subseq uri start end))
 		 (setf uri (subseq uri end))))
 	     (multiple-value-bind (start end) (scan token uri)  ;;else
 	       (declare (ignore start))
 	       (setf uri (subseq uri end)))))
-    map))
+    map)))
   
 
     

--- a/defrest.lisp
+++ b/defrest.lisp
@@ -161,7 +161,8 @@ Example 4:
 (defun create-query-param-parser (binding &key (mandatory nil) (pattern nil) (param nil) (default nil) &allow-other-keys)
   "Compiles the query definition into a function that is to be called with the query parameters
 of the current request and returns the value of the query parameter"
-  (let ((query-param-name (if param param (symbol-name binding))))
+  (let ((query-param-name (if param param (symbol-name binding)))
+	(scanner (if pattern (cl-ppcre:create-scanner pattern) nil)))
     (lambda (request-query-params)
       (let ((qp-value
 	     (cdr
@@ -171,10 +172,9 @@ of the current request and returns the value of the query parameter"
 	       :test (lambda (a b)
 		       (string= (string-upcase a) (string-upcase b)))))))
 	(cond
-	  ((and qp-value pattern)
+	  ((and qp-value scanner)
 	   (when (not 
-		  (scan 
-		   pattern qp-value))
+		  (scan scanner qp-value))
 	     (error (make-condition
 		     'hunchentoot:bad-request
 		     :format-control "Request validation failed: Query parameter ~a does not match pattern ~a"

--- a/defrest.lisp
+++ b/defrest.lisp
@@ -109,7 +109,7 @@ Example 4:
 	   
 
 (Defun parse-uri (schema uri)
-  "Parses URI against SCHEMA and returns a hashtable with all pathvariable bindings and the query parameters"
+  "Parses URI against SCHEMA and returns a hashtable with all pathvariable bindings and as second value the query parameters"
   (let ((parsed-uri (quri:uri (hunchentoot:url-decode uri))))
     (setf uri (quri:uri-path parsed-uri))
     (when (not 

--- a/defrest.lisp
+++ b/defrest.lisp
@@ -129,7 +129,7 @@ Example 4:
 	     (multiple-value-bind (start end) (scan token uri)  ;;else
 	       (declare (ignore start))
 	       (setf uri (subseq uri end)))))
-    map)))
+    (values map (quri:uri-query-params parsed-uri)))))
   
 
     

--- a/script/run-tests.lisp
+++ b/script/run-tests.lisp
@@ -1,0 +1,8 @@
+
+;;; Initialize quicklisp (copied from .sbclrc)
+(let ((quicklisp-init (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname))))
+  (when (probe-file quicklisp-init)
+    (load quicklisp-init)))
+
+(asdf:oos 'asdf:test-op 'defrest)
+

--- a/script/sbcl-run-tests.sh
+++ b/script/sbcl-run-tests.sh
@@ -1,0 +1,4 @@
+
+# Run tests with sbcl
+sbcl --script run-tests.lisp
+

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -33,13 +33,17 @@
     (is (= 2
 	   (hash-table-count result)))))
 (test testuriparse-with-query-params ()
-  (let ((result (defrest::parse-uri "/test/{id:[0-5]}{name:.+}" "/test/3A%20B?nickname=Freako")))
+  (multiple-value-bind (result query) (defrest::parse-uri "/test/{id:[0-5]}{name:.+}" "/test/3A%20B?nickname=Freako")
     (is (equal "A B"
 	       (gethash "name" result)))
     (is (equal "3"
 	       (gethash "id" result)))
     (is (= 2
-	   (hash-table-count result)))))
+	   (hash-table-count result)))
+    (is (= 1
+	   (length query)))
+    (is (string= "nickname" (car (first query))))
+    (is (string= "Freako" (cdr (first query))))))
 
 (test test-real-hunchentoot ()
   (let* ((port 9876)

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -33,6 +33,14 @@
 	       (gethash "id" result)))
     (is (= 2
 	   (hash-table-count result)))))
+(test testuriparse-with-query-params ()
+  (let ((result (defrest::parse-uri "/test/{id:[0-5]}{name:.+}" "/test/3A%20B?nickname=Freako")))
+    (is (equal "A B"
+	       (gethash "name" result)))
+    (is (equal "3"
+	       (gethash "id" result)))
+    (is (= 2
+	   (hash-table-count result)))))
 
 (test test-real-hunchentoot ()
   (let* ((port 9876)
@@ -59,6 +67,8 @@
 		      (drakma:http-request (url "/simple"))))
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk"))))
+	   (is (equal "Hello Bonk"
+		      (drakma:http-request (url "/greet/Bonk?nickname=Freako"))))
 	   (is (equal "Hello Mr./Mrs. Freak"
 		      (drakma:http-request (url "/greet/Mr./Mrs.%20Freak"))))
 	   (is (equal "3.0"

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -66,6 +66,9 @@
 	   (defrest "/greetquery/{name:.+}" :GET (name :query nickname age)
 	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
 
+	   (defrest "/greetqueryonly" :GET (:query name)
+	     (format nil "Hello ~a" name))
+	   
 	   (defrest "/greetquerymandatory/{name:.+}" :GET (name :query (nickname :mandatory t))
 	     (format nil "Hello ~a! Your nickname is ~a" name nickname))
 
@@ -77,7 +80,7 @@
 
 	   (defrest "/greetqueryparam/{name:.+}" :GET (name :query nickname (age :param "queryage" :pattern "[0-9]+"))
 	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
-	   
+
 	   (defrest "/post/{number:[0-9]+}.data" :POST (number)
 	     (sqrt (parse-integer number)))
 
@@ -85,6 +88,8 @@
 		      (drakma:http-request (url "/simple"))))
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk"))))
+	   (is (equal "Hello Bonk"
+		      (drakma:http-request (url "/greetqueryonly?name=Bonk"))))
 	   (is (equal "Hello Bonk! Your nickname is Freako and your age is NIL"
 		      (drakma:http-request (url "/greetquery/Bonk?nickname=Freako"))))
 	   (is (equal "Hello Bonk! Your nickname is Freako and your age is 21"

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -7,7 +7,6 @@
 
 (in-suite defrest-tests)
 
-
 (test testurlfiddling ()
   (is (equal 
        "/test/[0-9]+/gna"
@@ -60,9 +59,21 @@
 	   (defrest "/greet/{name:.+}" :GET (name)
 	     (concatenate 'string "Hello " name))
 
-	   (defrest "/greetquery/{name:.+}" :GET (name :query (nickname nil))
+	   (defrest "/greetquery/{name:.+}" :GET (name :query nickname age)
+	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
+
+	   (defrest "/greetquerymandatory/{name:.+}" :GET (name :query (nickname :mandatory t))
 	     (format nil "Hello ~a! Your nickname is ~a" name nickname))
 
+	   (defrest "/greetquerydefault/{name:.+}" :GET (name :query nickname (age :default "21"))
+	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
+
+	   (defrest "/greetquerypattern/{name:.+}" :GET (name :query nickname (age :pattern "[0-9]+"))
+	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
+
+	   (defrest "/greetqueryparam/{name:.+}" :GET (name :query nickname (age :param "queryage" :pattern "[0-9]+"))
+	     (format nil "Hello ~a! Your nickname is ~a and your age is ~a" name nickname age))
+	   
 	   (defrest "/post/{number:[0-9]+}.data" :POST (number)
 	     (sqrt (parse-integer number)))
 
@@ -70,9 +81,28 @@
 		      (drakma:http-request (url "/simple"))))
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk"))))
-	   
-	   (is (equal "Hello Bonk! Your nickname is Zausel"
+	   (is (equal "Hello Bonk! Your nickname is Freako and your age is NIL"
 		      (drakma:http-request (url "/greetquery/Bonk?nickname=Freako"))))
+	   (is (equal "Hello Bonk! Your nickname is Freako and your age is 21"
+		      (drakma:http-request (url "/greetquery/Bonk?nickname=Freako&age=21"))))
+
+	   (is (equal 400
+		      (second (multiple-value-list(drakma:http-request (url "/greetquerymandatory/Bonk"))))))
+
+	   (is (equal "Hello Bonk! Your nickname is Freako and your age is 21"
+		      (drakma:http-request (url "/greetquerypattern/Bonk?nickname=Freako&age=21"))))
+	   
+	   (is (equal 400
+		      (second (multiple-value-list(drakma:http-request (url "/greetquerypattern/Bonk?age=ABCD"))))))
+	   
+	   (is (equal "Hello Bonk! Your nickname is Freako and your age is 21"
+		      (drakma:http-request (url "/greetquerydefault/Bonk?nickname=Freako"))))
+
+	   (is (equal "Hello Bonk! Your nickname is Freako and your age is 21"
+		      (drakma:http-request (url "/greetqueryparam/Bonk?nickname=Freako&queryage=21"))))
+
+	   (is (equal 400
+		      (second (multiple-value-list(drakma:http-request (url "/greetqueryparam/Bonk?queryage=ABCD"))))))
 	   
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk?nickname=Freako"))))

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -59,7 +59,10 @@
 	   
 	   (defrest "/greet/{name:.+}" :GET (name)
 	     (concatenate 'string "Hello " name))
-	   
+
+	   (defrest "/greetquery/{name:.+}" :GET (name :query (nickname nil))
+	     (format nil "Hello ~a! Your nickname is ~a" name nickname))
+
 	   (defrest "/post/{number:[0-9]+}.data" :POST (number)
 	     (sqrt (parse-integer number)))
 
@@ -67,6 +70,10 @@
 		      (drakma:http-request (url "/simple"))))
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk"))))
+	   
+	   (is (equal "Hello Bonk! Your nickname is Zausel"
+		      (drakma:http-request (url "/greetquery/Bonk?nickname=Freako"))))
+	   
 	   (is (equal "Hello Bonk"
 		      (drakma:http-request (url "/greet/Bonk?nickname=Freako"))))
 	   (is (equal "Hello Mr./Mrs. Freak"


### PR DESCRIPTION
Added support of query parameters. Also added a bash script to run unit tests with SBCL (the script depends on Quicklisp). Changed unit-test execution code in defrest.asd to be compatible with FiveAM v1.3 (the change is backward compatible with FiveAM v1.2).